### PR TITLE
Add nullCatalogMeansCurrent=true

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-spring.datasource.url=jdbc:mysql://localhost/example1?useSSL=false
+spring.datasource.url=jdbc:mysql://localhost/example1?useSSL=false&nullCatalogMeansCurrent=true
 spring.datasource.username=example
 spring.datasource.password=example
 logging.level.org.springframework.jdbc.core.JdbcTemplate=DEBUG


### PR DESCRIPTION
The default value of property nullCatalogMeansCurrent has been changed in mysql-driver 5.x and 8.x. In 5.x, the default value is true, and in 8.x false, so in 5.x DatabaseMetaData.getTables will return tables exactlly from 'example1', and in 8.x DatabaseMetaData.getTables will return tables not only from 'example1' but from all databases, that's why the SQL will change to 'INSERT INTO persons (lastname) VALUES (?)'.
Workaround, add nullCatalogMeansCurrent=true in conn url when using mysql-driver 8.x, all tests pass successfully.